### PR TITLE
Sleep instead when there's no audio in the buffer

### DIFF
--- a/transcribe_demo.py
+++ b/transcribe_demo.py
@@ -128,7 +128,7 @@ def main():
                     print(line)
                 # Flush stdout.
                 print('', end='', flush=True)
-
+            else:
                 # Infinite loops are bad for processors, must sleep.
                 sleep(0.25)
         except KeyboardInterrupt:


### PR DESCRIPTION
Previous behavior only slept when there was audio in the buffer.

This caused two issues, it meant that quarter of a second pauses interrupted each record step, making the phrase timeout slightly inaccurate

And most importantly, it meant that the infinite loop wasn't being slept whenever there wasn't data in the queue, which makes it keep running with no pause