### PR TITLE
Change datetime.utcnow() to datetime.now()

### DIFF
--- a/transcribe_demo.py
+++ b/transcribe_demo.py
@@ -91,7 +91,7 @@ def main():
 
     while True:
         try:
-            now = datetime.utcnow()
+            now = datetime.now()
             # Pull raw recorded audio from the queue.
             if not data_queue.empty():
                 phrase_complete = False


### PR DESCRIPTION
Fixes deprecation warning. Functionally the same.