### PR TITLE
Add missing setuptools dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools
 pyaudio
 SpeechRecognition
 --extra-index-url https://download.pytorch.org/whl/cu116


### PR DESCRIPTION
Fixes:

```
❯ python transcribe_demo.py
Traceback (most recent call last):
  File "/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.9EpNkCCQK6/whisper_real_time/transcribe_demo.py", line 143, in <module>
    main()
  File "/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.9EpNkCCQK6/whisper_real_time/transcribe_demo.py", line 60, in main
    source = sr.Microphone(sample_rate=16000)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.9EpNkCCQK6/whisper_real_time/venv/lib/python3.12/site-packages/speech_recognition/__init__.py", line 80, in __init__
    self.pyaudio_module = self.get_pyaudio()
                          ^^^^^^^^^^^^^^^^^^
  File "/private/var/folders/ws/j7hn08fd2w17_q68394mdslr0000gn/T/tmp.9EpNkCCQK6/whisper_real_time/venv/lib/python3.12/site-packages/speech_recognition/__init__.py", line 111, in get_pyaudio
    from distutils.version import LooseVersion
ModuleNotFoundError: No module named 'distutils'
```
