### PR TITLE
Fix phrase patching and utcnow deprecation warning

### DIFF
--- a/transcribe_demo.py
+++ b/transcribe_demo.py
@@ -91,7 +91,7 @@ def main():
 
     while True:
         try:
-            now = datetime.utcnow()
+            now = datetime.now()
             # Pull raw recorded audio from the queue.
             if not data_queue.empty():
                 phrase_complete = False
@@ -120,7 +120,7 @@ def main():
                 if phrase_complete:
                     transcription.append(text)
                 else:
-                    transcription[-1] = text
+                    transcription[-1] = transcription[-1] + text
 
                 # Clear the console to reprint the updated transcription.
                 os.system('cls' if os.name=='nt' else 'clear')


### PR DESCRIPTION
I've found that partial phrases tend to be overwritten using `transcription[-1] = text` in the else statement. `transcription[-1] = transcription[-1] + text` will combine the previous partial phrase with the current partial phrase creating a complete phrase. There is some fallibility with the punctiation and capitlization produced via this method as they are treated as two seperate phrases, but I decided on this for personal use as it is more efficient. If that does bother you though, you can store and combine audio buffers or np arrays and pass that through the model again to construct a complete phrase with no errors of this sort. For my purposes this was a bit overkill so I decided against it. utcnow is also deprecated in favor of just datetime.now or datetime.now(timezone) so I fixed that aswell. 

