### PR TITLE
Add phrase_bytes to keep track of current phrase's audio data

### DIFF
--- a/transcribe_demo.py
+++ b/transcribe_demo.py
@@ -36,6 +36,8 @@ def main():
     phrase_time = None
     # Thread safe Queue for passing data from the threaded recording callback.
     data_queue = Queue()
+    # Bytes object which holds audio data for the current phrase
+    phrase_bytes = bytes()
     # We use SpeechRecognizer to record our audio because it has a nice feature where it can detect when speech ends.
     recorder = sr.Recognizer()
     recorder.energy_threshold = args.energy_threshold
@@ -98,6 +100,7 @@ def main():
                 # If enough time has passed between recordings, consider the phrase complete.
                 # Clear the current working audio buffer to start over with the new data.
                 if phrase_time and now - phrase_time > timedelta(seconds=phrase_timeout):
+                    phrase_bytes = bytes()
                     phrase_complete = True
                 # This is the last time we received new audio data from the queue.
                 phrase_time = now
@@ -105,11 +108,14 @@ def main():
                 # Combine audio data from queue
                 audio_data = b''.join(data_queue.queue)
                 data_queue.queue.clear()
-                
+
+                # Add the new audio data to the accumulated data for this phrase
+                phrase_bytes += audio_data
+
                 # Convert in-ram buffer to something the model can use directly without needing a temp file.
                 # Convert data from 16 bit wide integers to floating point with a width of 32 bits.
                 # Clamp the audio stream frequency to a PCM wavelength compatible default of 32768hz max.
-                audio_np = np.frombuffer(audio_data, dtype=np.int16).astype(np.float32) / 32768.0
+                audio_np = np.frombuffer(phrase_bytes, dtype=np.int16).astype(np.float32) / 32768.0
 
                 # Read the transcription.
                 result = audio_model.transcribe(audio_np, fp16=torch.cuda.is_available())


### PR DESCRIPTION
Sorry davabase, this ended up being slightly more than I originally thought. Isn't it always? 😆 

This PR adds a `bytes` object which keeps track of previously-accumulated phrase data, until the phrase is complete. This used to be accomplished by a similar variable named `last_sample`, but that was removed when the update was made not to write to disk in 973880412aa4ac398543b9e34de116be715886d9.

Results before my changes:
![withoutmychanges](https://github.com/user-attachments/assets/27abab3d-0ec3-4e38-b294-7f0822520a77)

Results after my changes:
![withmychanges](https://github.com/user-attachments/assets/476496a1-2bec-45eb-a9c3-865c96d4b049)

Cheers! ❤️ 